### PR TITLE
Added a trick for evasion

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ LoadDriver.exe /LOAD
 LoadDriver.exe /UNLOAD  
 
 Another evasion technique to load the driver without the victim noticing could be by  
-abusing normal procexp.exe features  (EDRs and XDRs might notice an unsigned EXE loading a driver and adding reg key)  
+abusing normal procexp.exe features  (EDRs and XDRs might notice an unsigned EXE loading a driver and adding reg key, therefore this trick is very useful!)  
 ```  
 .\procexp64.exe -accepteula /t  
 ```  

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 LoadDriver.exe /LOAD  
 LoadDriver.exe /UNLOAD  
 
+### Evasion Alert:  
 EDRs and XDRs might notice an unsigned EXE loading a driver and adding a registry key, therefore the following trick was found.  
 Obivously opening procexp will alert the victim and would look weird, so by using the `/t` flag, procexp will be opened  
 minimized and the driver will be loaded by the `procexp64.exe` signed binary.  

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ LoadDriver.exe /UNLOAD
 Another evasion technique to load the driver without the victim noticing could be by  
 abusing normal procexp.exe features  (EDRs and XDRs might notice an unsigned EXE loading a driver and adding reg key)  
 ```  
-\procexp64.exe -accepteula /t  
+.\procexp64.exe -accepteula /t  
 ```  

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@
 LoadDriver.exe /LOAD  
 LoadDriver.exe /UNLOAD  
 
-Another evasion technique to load the driver without the victim noticing could be by  
-abusing normal procexp.exe features  (EDRs and XDRs might notice an unsigned EXE loading a driver and adding reg key, therefore this trick is very useful!)  
+EDRs and XDRs might notice an unsigned EXE loading a driver and adding a registry key, therefore the following trick was found.  
+Obivously opening procexp will alert the victim and would look weird, so by using the `/t` flag, procexp will be opened  
+minimized and the driver will be loaded by the `procexp64.exe` signed binary.  
 ```  
 .\procexp64.exe -accepteula /t  
 ```  

--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@
 <br/>PS: Added Implementation to load the driver manually without ProcessExplorer.  
 LoadDriver.exe /LOAD  
 LoadDriver.exe /UNLOAD  
+
+Another evasion technique to load the driver without the victim noticing could be by  
+abusing normal procexp.exe features  (EDRs and XDRs might notice an unsigned EXE loading a driver and adding reg key)  
+```  
+\procexp64.exe -accepteula /t  
+```  


### PR DESCRIPTION
While exploring the method, I found that some EDRs are alerted by unsigned EXE loading the driver and creating a Registry Key, therefore I explored procexp.exe a bit further and found the `/t` flag.  